### PR TITLE
Expose bool to BP for movement constraint

### DIFF
--- a/SeattleSlowJam/Source/SeattleSlowJam/CabinCharacter.cpp
+++ b/SeattleSlowJam/Source/SeattleSlowJam/CabinCharacter.cpp
@@ -100,7 +100,7 @@ void ACabinCharacter::LookUpAtRate(float Rate)
 
 void ACabinCharacter::MoveForward(float Value)
 {
-	if ((Controller != nullptr) && (Value != 0.0f) && bIsThirdPersonMode == true)
+	if ((Controller != nullptr) && (Value != 0.0f) && !bIsMovementConstrained)
 	{
 		// find out which way is forward
 		const FRotator Rotation = Controller->GetControlRotation();
@@ -191,15 +191,7 @@ void ACabinCharacter::RotateItemLeft()
 
 
 //--------------------------------- Character Mode Switch -------------------------------------------
-void ACabinCharacter::SwitchMovementMode()
+void ACabinCharacter::ShouldConstrainMovement(bool bShouldConstrainMovement)
 {
-	if (bIsThirdPersonMode)
-	{
-		bIsThirdPersonMode = false;
-
-	}
-	else
-	{
-		bIsThirdPersonMode = true;
-	}
+	bIsMovementConstrained = bShouldConstrainMovement;
 }

--- a/SeattleSlowJam/Source/SeattleSlowJam/CabinCharacter.h
+++ b/SeattleSlowJam/Source/SeattleSlowJam/CabinCharacter.h
@@ -36,7 +36,7 @@ public:
 	float BaseLookUpRate;
 
 	UFUNCTION(BlueprintCallable)
-	void SwitchMovementMode();
+	void ShouldConstrainMovement(bool bShouldConstrainMovement);
 
 protected:
 	/** Called for forwards/backward input */
@@ -76,7 +76,7 @@ protected:
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 	// End of APawn interface
 private:
-	bool bIsThirdPersonMode = true;
+	bool bIsMovementConstrained = false;
 
 public:
 	/** Returns CameraBoom subobject **/


### PR DESCRIPTION
Changes method to expose the boolean that controls movement constraint
to the blueprint.